### PR TITLE
Added Livecode synonym for LiveCode

### DIFF
--- a/lib/stat_generator.rb
+++ b/lib/stat_generator.rb
@@ -56,7 +56,7 @@ class StatGenerator
     "Less" => %w(less),
     "Lisp" => %w(lisp),
     "Lingo" => %w(lingo),
-    "LiveCode" => %w(livecode),
+    "LiveCode" => %w(livecode Livecode),
     "Livescript" => %w(livescript),
     "Logo" => %w(logo),
     "Lua" => %w(lua),


### PR DESCRIPTION
I noticed that somebody had typed Livecode instead of LiveCode or livecode. I've updated the list of synonyms.
